### PR TITLE
Fix events getting delivered multiple times

### DIFF
--- a/Project/Sources/FileSystemEventMonitor.swift
+++ b/Project/Sources/FileSystemEventMonitor.swift
@@ -46,8 +46,8 @@ public final class FileSystemEventMonitor {
 				let	ID		=	eventIds[i]
 				let	ev		=	FileSystemEvent(path: path, flag: FileSystemEventFlag(rawValue: flag), ID: ID)
 				a1.append(ev)
-				callback(events: a1)
 			}
+			callback(events: a1)
 		}
 		
 		let	ps2	=	pathsToWatch.map({ $0 as NSString }) as [AnyObject]


### PR DESCRIPTION
Hi!

I'm using for your FileSystemEvents library for a project and noticed that my application callback received file system events multiple times. Specifically, when multiple files changed at once, let's say A,B and C, then the callback would get called three times, once with [A], once with [A,B] and once with [A,B,C]. This did not seem like intended behavior to me, so I investigated and made the attached attached change (moving the call to the callback outside of the event transformation loop).  

Not sure if the notification style was intentional or a bug... but to me it makes more sense this way :-)
Anyway, nice project, thanks for publishing it.
